### PR TITLE
fix: pre-commit hook for commitizen

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -103,6 +103,7 @@
     commitizen = {
       enable = true;
       description = "Check wheater the current commit message follows committing rules";
+      stages = ["commit-msg"];
     };
 
     detect-private-keys = {


### PR DESCRIPTION
Change `commitizen` pre-commit hook stage to `commit-msg`.
