### PR TITLE
ci(clang-tidy): add clang-tidy linter via rules_lint

### DIFF
--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -1,0 +1,3 @@
+lint:
+  aspects:
+    - //bzl/lint:linters.bzl%clang_tidy

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,5 @@
+# https://clang.llvm.org/extra/clang-tidy/
+# config-file to provoke some checks in example
+Checks: "*, -abseil-*, -altera-*, -android-*, -fuchsia-*, -google-*, -llvm*, -modernize-use-trailing-return-type, -zircon-*, -readability-else-after-return, -readability-static-accessed-through-instance, -readability-avoid-const-params-in-decls, -cppcoreguidelines-non-private-member-variables-in-classes, -misc-non-private-member-variables-in-classes,"
+# promote a random warning to error to test integration. Do not copy this line.
+WarningsAsErrors: "readability-inconsistent-declaration-parameter-name"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,12 @@
 load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
+exports_files(
+    [
+        ".clang-tidy",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 alias(
     name = "format",
     actual = "//bzl/format",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,7 +31,8 @@ use_repo(doxygen_extension, "doxygen")
 # Formatting and Linting
 # https://github.com/aspect-build/rules_lint
 bazel_dep(name = "aspect_rules_lint", version = "1.2.2")
-
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
 # Hedron's Compile Commands Extractor for Bazel
 # https://github.com/hedronvision/bazel-compile-commands-extractor
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -202,7 +202,7 @@
     "@@aspect_bazel_lib~//lib:extensions.bzl%toolchains": {
       "general": {
         "bzlTransitiveDigest": "lIywunPSkJhCp6mXUfksrSPKxf9cWiIiLudbktooWUQ=",
-        "usagesDigest": "0KwHJIwcF+QQ3fZSlwUpqyTJ3McKhsUPXuTXpJ/D6vM=",
+        "usagesDigest": "lOkH8a1A8OsC6mGyCVt+R5p/3M3r0O+QiUxv+qfU5t8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -844,7 +844,7 @@
     "@@rules_doxygen~//:extensions.bzl%doxygen_extension": {
       "general": {
         "bzlTransitiveDigest": "LmEOagNxiU9i+X/SwfrOTTnA/Z/T+AgTohersbxJNtY=",
-        "usagesDigest": "DinjjK6HUCHpf/Du/wSUc6Q4l1LlRMXLiaiDTH8ZTlQ=",
+        "usagesDigest": "fhf33DMoLe80vJhH+z2ckw59z2J0Q7ko+8A1jqcvx+U=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/bzl/lint/BUILD.bazel
+++ b/bzl/lint/BUILD.bazel
@@ -1,0 +1,24 @@
+"""Definition of the linter binary
+
+This is in its own package because it has so many loading-time symbols,
+we don't want to trigger eager fetches of these for builds that don't want to run format.
+"""
+
+load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@aspect_rules_lint//lint:vale_library.bzl", "VALE_STYLES")
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+package(default_visibility = ["//:__subpackages__"])
+
+native_binary(
+    name = "clang_tidy",
+    src = select(
+        {
+            "@bazel_tools//src/conditions:linux_x86_64": "@llvm_toolchain//:clang-tidy",
+            "@bazel_tools//src/conditions:linux_aarch64": "@llvm_toolchain//:clang-tidy",
+            "@bazel_tools//src/conditions:darwin_x86_64": "@llvm_toolchain//:clang-tidy",
+            "@bazel_tools//src/conditions:darwin_arm64": "@llvm_toolchain//:clang-tidy",
+        },
+    ),
+    out = "clang_tidy",
+)

--- a/bzl/lint/linters.bzl
+++ b/bzl/lint/linters.bzl
@@ -1,0 +1,22 @@
+"Define linter aspects"
+
+load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
+load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
+# load("@aspect_rules_lint//lint:shellcheck.bzl", "lint_shellcheck_aspect")
+
+# shellcheck = lint_shellcheck_aspect(
+#     binary = "@multitool//tools/shellcheck",
+#     config = Label("@//:.shellcheckrc"),
+# )
+#
+# shellcheck_test = lint_test(aspect = shellcheck)
+
+clang_tidy = lint_clang_tidy_aspect(
+    binary = "@@//bzl/lint:clang_tidy",
+    global_config = "@@//:.clang-tidy",
+    lint_target_headers = True,
+    angle_includes_are_system = False,
+    verbose = False,
+)
+
+clang_tidy_test = lint_test(aspect = clang_tidy)


### PR DESCRIPTION
<!-- Provide a short summary of the change introduced by the PR. -->
# Summary

Add [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) support via [rules_lint](https://github.com/aspect-build/rules_lint)

---------
Issue number: resolves #14 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc).
     Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

There's no support for linters.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- [x] Trigger the linter via the [Aspect CLI](https://docs.aspect.build/cli/commands/aspect_lint)
- [ ] Pull Request Bot runs the linter and provides feedback as comments

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

<!-- Any other information that is important to this PR such as screenshots of
    how the component looks before and after the change. -->
