### PR TITLE
feat(cross-compile): cross-compile from x86_64 to aarch64

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -86,30 +86,31 @@ http_archive(
 # Configure and register the toolchain.
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
 
-# LLVM Versions and platforms
-# https://github.com/bazel-contrib/toolchains_llvm/blob/master/toolchain/internal/llvm_distributions.bzl
-# llvm.toolchain(
-#     name = "llvm_toolchain",
-#     llvm_version = "18.1.7",
-#     stdlib = {
-#         "linux-x86_64": "stdc++",
-#         "linux-aarch64": "stdc++",
-#     },
-#     cxx_standard = {
-# 	"18.1.7": "c++20",
-#     },
-# )
 llvm.toolchain(
     name = "llvm_toolchain",
     llvm_version = "19.1.6",
-    sha256 = {"linux-x86_64": "d55dcbb309de7ade4e3073ec3ac3fac4d3ff236d54df3c4de04464fe68bec531"},
+    sha256 = {
+        "linux-x86_64": "d55dcbb309de7ade4e3073ec3ac3fac4d3ff236d54df3c4de04464fe68bec531",
+        "linux-aarch64": "d55dcbb309de7ade4e3073ec3ac3fac4d3ff236d54df3c4de04464fe68bec531",
+    },
     strip_prefix = {
         "linux-x86_64": "LLVM-19.1.6-Linux-X64",
+        "linux-aarch64": "clang+llvm-19.1.6-aarch64-linux-gnu",
     },
     urls = {
         "linux-x86_64": [
             "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.6/LLVM-19.1.6-Linux-X64.tar.xz",
         ],
+        "linux-aarch64": [
+            "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.6/clang+llvm-19.1.6-aarch64-linux-gnu.tar.xz",
+        ],
+    },
+    stdlib = {
+        "linux-x86_64": "stdc++",
+        "linux-aarch64": "stdc++",
+    },
+    cxx_standard = {
+        "19.1.6": "c++23",
     },
 )
 llvm.sysroot(
@@ -119,6 +120,7 @@ llvm.sysroot(
 )
 llvm.sysroot(
     name = "llvm_toolchain",
+    label = "@sysroot_linux_aarch64//:sysroot",
     targets = ["linux-aarch64"],
 )
 use_repo(llvm, "llvm_toolchain")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1295,7 +1295,7 @@
     "@@toolchains_llvm~//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
         "bzlTransitiveDigest": "afRF0aFOIUrkYl3o040WQ606ep1qciEXzjnAxT3Kek8=",
-        "usagesDigest": "gts6FUCL96v3mTcyYlvbEsMmfJ/ue2GTI/DT5H+2CI8=",
+        "usagesDigest": "hw228HF4+MmGeFK34Ic0lSwufwwsVaPAHYc1AypyGN0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1315,14 +1315,19 @@
               "llvm_versions": {},
               "netrc": "",
               "sha256": {
-                "linux-x86_64": "d55dcbb309de7ade4e3073ec3ac3fac4d3ff236d54df3c4de04464fe68bec531"
+                "linux-x86_64": "d55dcbb309de7ade4e3073ec3ac3fac4d3ff236d54df3c4de04464fe68bec531",
+                "linux-aarch64": "d55dcbb309de7ade4e3073ec3ac3fac4d3ff236d54df3c4de04464fe68bec531"
               },
               "strip_prefix": {
-                "linux-x86_64": "LLVM-19.1.6-Linux-X64"
+                "linux-x86_64": "LLVM-19.1.6-Linux-X64",
+                "linux-aarch64": "clang+llvm-19.1.6-aarch64-linux-gnu"
               },
               "urls": {
                 "linux-x86_64": [
                   "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.6/LLVM-19.1.6-Linux-X64.tar.xz"
+                ],
+                "linux-aarch64": [
+                  "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.6/clang+llvm-19.1.6-aarch64-linux-gnu.tar.xz"
                 ]
               }
             }
@@ -1339,7 +1344,9 @@
               "coverage_link_flags": {},
               "cxx_builtin_include_directories": {},
               "cxx_flags": {},
-              "cxx_standard": {},
+              "cxx_standard": {
+                "19.1.6": "c++23"
+              },
               "dbg_compile_flags": {},
               "exec_arch": "",
               "exec_os": "",
@@ -1352,13 +1359,16 @@
               },
               "opt_compile_flags": {},
               "opt_link_flags": {},
-              "stdlib": {},
+              "stdlib": {
+                "linux-x86_64": "stdc++",
+                "linux-aarch64": "stdc++"
+              },
               "target_settings": {},
               "unfiltered_compile_flags": {},
               "toolchain_roots": {},
               "sysroot": {
                 "linux-x86_64": "'@@_main~_repo_rules~sysroot_linux_x64//:sysroot'",
-                "linux-aarch64": "None"
+                "linux-aarch64": "'@@_main~_repo_rules~sysroot_linux_aarch64//:sysroot'"
               }
             }
           }

--- a/standalone/BUILD.bazel
+++ b/standalone/BUILD.bazel
@@ -4,14 +4,14 @@ load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 package(default_visibility = ["//visibility:public"])
 
 cc_binary(
-    name = "my-cool-app",
+    name = "hello-world",
     srcs = ["main.cpp"],
 )
 
 # Packaging the binary into tar, which is needed by oci_image rule
 pkg_tar(
     name = "tar",
-    srcs = [":my-cool-app"],
+    srcs = [":hello-world"],
 )
 
 # Making image
@@ -22,14 +22,14 @@ oci_image(
     name = "image",
     base = "@docker_lib_ubuntu",
     tars = [":tar"],
-    entrypoint = ["/my-cool-app"],
+    entrypoint = ["/hello-world"],
 )
 
 oci_push(
     name = "push_image",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "ghcr.io/alemoreno991/my-cool-app",
+    repository = "ghcr.io/alemoreno991/hello-world",
 )
 
 # Use with 'bazel run' to load the oci image into a container runtime.
@@ -37,5 +37,5 @@ oci_push(
 oci_load(
     name = "image_load",
     image = ":image",
-    repo_tags = ["my-cool-app:latest"],
+    repo_tags = ["hello-world:latest"],
 )


### PR DESCRIPTION
<!-- Provide a short summary of the change introduced by the PR. -->
# Summary

Cross-compile from `x86_64` to `aarch64` and generate tarball.

---------
Issue number: resolves #11

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc).
     Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

One can cross-compile from `x86_64` to `aarch64` by executing `bazelisk build --platforms=@toolchains_llvm//platforms:linux-aarch64 standalone:hello-world`.

```shell
# Build binary for x86_64
bazelisk build --platforms=@toolchains_llvm//platforms:linux-x86_64 standalone:hello-world
# Generate the tarball with the x86_64 binary
bazelisk build --platforms=@toolchains_llvm//platforms:linux-x86_64 standalone:tar
```

```shell
# Build binary for aarch64
bazelisk build --platforms=@toolchains_llvm//platforms:linux-aarch64 standalone:hello-world
# Generate the tarball with the aarch64 binary
bazelisk build --platforms=@toolchains_llvm//platforms:linux-aarch64 standalone:tar
```

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Modify the llvm_toolchain rule to add cross-compilation capabilities from x86_64 to aarch64.
- Generate tarball with the binary (x86_64 or aarch64)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
