### PR TITLE
Amo/36 bazel generate oci image for aarch64

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -135,7 +135,7 @@ register_toolchains(
 #
 # TIP: For testing, https://registry.bazel.build/modules/container_structure_test
 ###############################################################################
-bazel_dep(name = "rules_oci", version = "2.2.5")
+bazel_dep(name = "rules_oci", version = "2.2.6")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "tweag-credential-helper", version = "0.0.5")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -130,8 +130,8 @@
     "https://bcr.bazel.build/modules/rules_multitool/0.4.0/source.json": "d73b450b7c6d9683e400d6cebc463fbc2b870cc5d8e2e75080d6278805aaab08",
     "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/MODULE.bazel": "6bc03c8f37f69401b888023bf511cb6ee4781433b0cb56236b2e55a21e3a026a",
     "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/source.json": "6e82cf5753d835ea18308200bc79b9c2e782efe2e2a4edc004a9162ca93382ca",
-    "https://bcr.bazel.build/modules/rules_oci/2.2.5/MODULE.bazel": "9086fa85e46ca1116317f64e031403ce73eaf214ad9251ee3bdf3199734cf2ac",
-    "https://bcr.bazel.build/modules/rules_oci/2.2.5/source.json": "4cf66bdafeb0df214d43e0e4b1a442223bca421f62d38650b466cbb001894293",
+    "https://bcr.bazel.build/modules/rules_oci/2.2.6/MODULE.bazel": "2ba6ddd679269e00aeffe9ca04faa2d0ca4129650982c9246d0d459fe2da47d9",
+    "https://bcr.bazel.build/modules/rules_oci/2.2.6/source.json": "94e7decb8f95d9465b0bbea71c65064cd16083be1350c7468f131818641dc4a5",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
@@ -202,7 +202,7 @@
     "@@aspect_bazel_lib~//lib:extensions.bzl%toolchains": {
       "general": {
         "bzlTransitiveDigest": "lIywunPSkJhCp6mXUfksrSPKxf9cWiIiLudbktooWUQ=",
-        "usagesDigest": "0KwHJIwcF+QQ3fZSlwUpqyTJ3McKhsUPXuTXpJ/D6vM=",
+        "usagesDigest": "VQPJvEM15+ovRW0xNQja0BwfJOShh/rRtsClNEh726I=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1071,7 +1071,7 @@
     "@@rules_oci~//oci:extensions.bzl%oci": {
       "general": {
         "bzlTransitiveDigest": "+s9/DJt7alL28GJQAJYzXrUZUQNjOhuIi5I4ZLG9D/c=",
-        "usagesDigest": "xHte3lmEoL/q9Ge+OWbMaiEkVMxpV6djGigzlmwKvck=",
+        "usagesDigest": "NkupuxQ9ZsK0TeLvPqzVBGHuzVGJstg1YT+OL6u82x8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/bzl/transition.bzl
+++ b/bzl/transition.bzl
@@ -1,0 +1,27 @@
+"a rule transitioning an oci_image to multiple platforms"
+
+def _multiarch_transition(settings, attr):
+    return [
+        {"//command_line_option:platforms": str(platform)}
+        for platform in attr.platforms
+    ]
+
+multiarch_transition = transition(
+    implementation = _multiarch_transition,
+    inputs = [],
+    outputs = ["//command_line_option:platforms"],
+)
+
+def _impl(ctx):
+    return DefaultInfo(files = depset(ctx.files.image))
+
+multi_arch = rule(
+    implementation = _impl,
+    attrs = {
+        "image": attr.label(cfg = multiarch_transition),
+        "platforms": attr.label_list(),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)

--- a/standalone/BUILD.bazel
+++ b/standalone/BUILD.bazel
@@ -19,23 +19,49 @@ pkg_tar(
 # Correspondigly, use language-specific distroless images.
 # Here we use docker.io/library/ubuntu image for this C++ program.
 oci_image(
-    name = "image",
+    name = "image_linux_x86_64",
     base = "@docker_lib_ubuntu",
     tars = [":tar"],
     entrypoint = ["/hello-world"],
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+oci_image(
+    name = "image_linux_aarch64",
+    base = "@docker_lib_ubuntu",
+    tars = [":tar"],
+    entrypoint = ["/hello-world"],
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
 )
 
 oci_push(
-    name = "push_image",
-    image = ":image",
+    name = "push_image_linux_x86_64",
+    image = ":image_linux_x86_64",
     remote_tags = ["latest"],
-    repository = "ghcr.io/alemoreno991/hello-world",
+    repository = "ghcr.io/alemoreno991/linux_x86_64/hello-world",
+)
+oci_push(
+    name = "push_image_linux_aarch64",
+    image = ":image_linux_aarch64",
+    remote_tags = ["latest"],
+    repository = "ghcr.io/alemoreno991/linux_aarch64/hello-world",
 )
 
 # Use with 'bazel run' to load the oci image into a container runtime.
 # The image is designated using `repo_tags` attribute.
 oci_load(
-    name = "image_load",
-    image = ":image",
+    name = "load_image_linux_x86_64",
+    image = ":image_linux_x86_64",
+    repo_tags = ["hello-world:latest"],
+)
+oci_load(
+    name = "load_image_linux_aarch64",
+    image = ":image_linux_aarch64",
     repo_tags = ["hello-world:latest"],
 )

--- a/standalone/BUILD.bazel
+++ b/standalone/BUILD.bazel
@@ -1,5 +1,6 @@
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_load")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//:bzl/transition.bzl", "multi_arch")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -19,49 +20,40 @@ pkg_tar(
 # Correspondigly, use language-specific distroless images.
 # Here we use docker.io/library/ubuntu image for this C++ program.
 oci_image(
-    name = "image_linux_x86_64",
+    name = "image",
     base = "@docker_lib_ubuntu",
     tars = [":tar"],
     entrypoint = ["/hello-world"],
-    target_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
+)
+
+multi_arch(
+    name = "images",
+    image = ":image",
+    platforms = [
+        "//bzl/platforms:linux-x86_64",
+        "//bzl/platforms:linux-aarch64",
     ],
 )
 
-oci_image(
-    name = "image_linux_aarch64",
-    base = "@docker_lib_ubuntu",
-    tars = [":tar"],
-    entrypoint = ["/hello-world"],
-    target_compatible_with = [
-        "@platforms//cpu:aarch64",
-        "@platforms//os:linux",
+oci_image_index(
+    name = "multiarch_image",
+    images = [
+        ":images"
     ],
 )
 
 oci_push(
-    name = "push_image_linux_x86_64",
-    image = ":image_linux_x86_64",
+    name = "push_multiarch_image",
+    image = ":multiarch_image",
     remote_tags = ["latest"],
-    repository = "ghcr.io/alemoreno991/linux_x86_64/hello-world",
-)
-oci_push(
-    name = "push_image_linux_aarch64",
-    image = ":image_linux_aarch64",
-    remote_tags = ["latest"],
-    repository = "ghcr.io/alemoreno991/linux_aarch64/hello-world",
+    repository = "ghcr.io/alemoreno991/multiarch/hello-world",
 )
 
 # Use with 'bazel run' to load the oci image into a container runtime.
 # The image is designated using `repo_tags` attribute.
 oci_load(
-    name = "load_image_linux_x86_64",
-    image = ":image_linux_x86_64",
-    repo_tags = ["hello-world:latest"],
-)
-oci_load(
-    name = "load_image_linux_aarch64",
-    image = ":image_linux_aarch64",
-    repo_tags = ["hello-world:latest"],
+    name = "load_multiarch_image",
+    image = ":multiarch_image",
+    format = "oci",
+    repo_tags = ["hello-world-ale:latest"],
 )


### PR DESCRIPTION
<!-- Provide a short summary of the change introduced by the PR. -->
# Summary

Generate OCI images for `x86_64` and `aarch64`

---------
Issue number: resolves #36 

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc).
     Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
It is only possible to generate oci-images for `x86_64`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Generate oci-images for `x86_64` or `aarch64` dependending on the selected platform
- Make the oci-images (`x86_64` or `aarch64`) available to docker or similar 
- Push the oci-images (`x86_64` or `aarch64`) to a container registry.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

<!-- Any other information that is important to this PR such as screenshots of
    how the component looks before and after the change. -->
It was considered the possibility of [creating a multi-architecture oci-image](https://github.com/bazel-contrib/rules_oci/blob/main/docs/image_index.md) but since the feature is still marked as **highly experimental** I decided against it. 