### PR TITLE
fix(credential-helper): fix unreliable behavior

### DIFF
--- a/tools/credential-helper
+++ b/tools/credential-helper
@@ -49,7 +49,7 @@ workdir_hash() {
     echo -n "${CREDENTIAL_HELPER_WORKSPACE_DIRECTORY}" | md5
   elif builtin command -v md5sum > /dev/null ; then
     local md5_array
-    md5_array="$(echo -n "${CREDENTIAL_HELPER_WORKSPACE_DIRECTORY}" | md5sum)"
+    md5_array="$(echo -n "${CREDENTIAL_HELPER_WORKSPACE_DIRECTORY}" | md5sum | awk '{print $1}' )"
     echo "${md5_array}"
   else
     echo "Neither md5 nor md5sum were found in the PATH" >&2


### PR DESCRIPTION
Fix unreliable behavior of the <HASH>
