### PR TITLE
ci(artifacts): upload and attach artifacts to releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,6 +46,40 @@ jobs:
           # Share repository cache between workflows.
           repository-cache: true
 
+      - name: Build & Push OCI Image
+        # Build and push OCI image to Image Registry
+        id: build-push-oci-image
+        run: |
+          # Build and push the oci images
+          # NOTE: this will generate tarballs as intermediate steps
+          SEMANTIC_VERSION="$(jq '.["."]' .release-please-manifest.json)"
+          bazelisk run standalone:push_image --revision_mode=RELEASE --release_version="${SEMANTIC_VERSION}"
+          # Save the image registry url where the oci image is stored
+          REGISTRY_URL=$(bazelisk cquery standalone:repositories --revision_mode=RELEASE --release_version="${SEMANTIC_VERSION}" --output files 2>/dev/null)
+          # Save the tag of the oci image
+          IMAGE_TAG=$(bazelisk cquery standalone:release-tags --revision_mode=RELEASE --release_version="${SEMANTIC_VERSION}" --output files 2>/dev/null)
+          # Save the paths where the tarballs are located
+          TARBALLS_PATHS=$(bazelisk cquery standalone:tar --revision_mode=RELEASE --release_version="${SEMANTIC_VERSION}" --output files 2>/dev/null)
+          {
+            # Make the registry_url and the image tag available as an output var
+            echo "REGISTRY_URL=${REGISTRY_URL}";
+            echo "IMAGE_TAG=${IMAGE_TAG}";
+            # Make the tarball path available as an output variable from this step
+            echo "TARBALL_AARCH64_PATH=$(${TARBALLS_PATHS} | grep aarch64)";
+            echo "TARBALL_X86_64_PATH=$(${TARBALLS_PATHS} | grep x86_64)"
+          } >> "GITHUB_OUTPUT"
+
+      - name: Upload tarball x86_64 (binaries) to release
+        uses: svenstaro/upload-release-action@v2
+        env:
+          REGISTRY_URL: ${{ steps.build-push-oci-image.outputs.REGISTRY_URL }}
+          IMAGE_TAG: ${{ steps.build-push-oci-image.outputs.IMAGE_TAG }}
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./{${{ steps.build-push-oci-image.outputs.TARBALL_X86_64_PATH }},${{ steps.build-push-oci-image.outputs.TARBALL_AARCH64_PATH }}}
+          tag: ${{ github.ref }}
+          body: "Pull the oci image as follows:\n> docker pull ${REGISTRY_URL}/${IMAGE_TAG}"
+
       - name: Build Documentation
         # Always use bazelisk rather than bazel to
         # guarantee that the correct version of Bazel


### PR DESCRIPTION
<!-- Provide a short summary of the change introduced by the PR. -->
# Summary

Upload and attach artifacts to releases
---------
Issue number: resolves #37

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc).
     Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
The capability of creating the tarballs and oci-images is implemented but the releases don't display them.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Automatic upload and attach of artifacts to releases.

- CI will automatically upload and attach the tarballs (x86_64 and aarch64) to a release
- CI will automatically include the oci image url for users to download.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging.
See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer
for more information.
-->

## Other information

<!-- Any other information that is important to this PR such as screenshots of
    how the component looks before and after the change. -->

- https://www.lucavall.in/blog/how-to-create-a-release-with-multiple-artifacts-from-a-github-actions-workflow-using-the-matrix-strategy
- https://github.com/marketplace/actions/upload-files-to-a-github-release
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter